### PR TITLE
terraform-provisioner-ansible: scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+terraform-provisioner-ansible

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,7 @@
+github.com/mitchellh/go-linereader
+github.com/hashicorp/terraform
+github.com/xanzy/ssh-agent
+github.com/packer-community/winrmcp/winrmcp
+github.com/nu7hatch/gouuid
+github.com/dylanmei/winrmtest
+github.com/mitchellh/go-homedir

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # terraform-provisioner-ansible
 An attempt at provisioning terraform instances with ansible
 
-**NOTE** this is not real software yet!
+Still a WIP but this `terraform` plugin provides a basic provisioner for
+bootstrapping `terraform` instance resources with ansible. 
+
+As a first pass, this uses a `local-ansible.py` script for running ansible
+locally on the host. Ansible code is shipped to the resource and run locally.
+This is to avoid having to introduce ansible as a dependency at the `terraform`
+layer and to simplify the responsibilities of this plugin.
+
+
+

--- a/ansible-local.py
+++ b/ansible-local.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#vim:syntax=python
+
+import argparse
+import collections
+import json
+import os.path
+import socket
+import subprocess
+import sys
+
+from ansible.vars import VariableManager
+from ansible.parsing.dataloader import DataLoader
+from ansible.inventory import Inventory
+from ansible.inventory import Host
+from ansible.inventory import Group
+from ansible.playbook import Playbook
+from ansible.executor.task_queue_manager import TaskQueueManager
+
+
+OptionsClass = collections.namedtuple('Options', ('connection', 'module_path', 'forks', 'remote_user', 'private_key_file',
+                                 'ssh_common_args', 'ssh_extra_args', 'sftp_extra_args', 'scp_extra_args',
+                                 'become', 'become_method', 'become_user', 'verbosity', 'check'))
+
+
+def build_inventory(loader, variable_manager, group_names):
+    inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=['localhost'])
+    host = inventory.get_hosts()[0]
+    
+    for group_name in group_names:
+        if not inventory.get_group(group_name):
+            group = Group(group_name)
+            inventory.add_group(group)
+
+        inventory.get_group(group_name).add_host(host)
+
+    return inventory
+
+
+def build_plays(loader, variable_manager, playbook_path, play_ids):
+    playbook = Playbook.load(playbook_path, variable_manager, loader)
+    plays = []
+    
+    for play in playbook.get_plays():
+        # a play can correspond to a play name or the host group
+        for play_id in play_ids:
+            if play.get_name() == play_id:
+                plays.append(play)
+            elif play._ds['hosts'] == play_id:
+                plays.append(play)
+
+    return plays
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='ansible-local script for running ansible against localhost')
+
+    parser.add_argument('--module-path', help='path to ansible source', required=True)
+    parser.add_argument('--playbook', help='path to playbook file', required=True)
+    parser.add_argument('--plays', help='list of plays to apply to host', required=True, type=lambda x: x.split(","))
+    parser.add_argument('--groups', help='list of groups to apply to host', required=True, type=lambda x: x.split(","))
+    parser.add_argument('--extra-vars', help='json encoded string with extra-var information', required=True, type=lambda x: json.loads(x))
+
+    args = parser.parse_args()
+    
+    options = OptionsClass(connection='local',
+                      module_path=args.module_path,
+                      forks=100,
+                      remote_user=None,
+                      private_key_file=None,
+                      ssh_common_args=None,
+                      ssh_extra_args=None,
+                      sftp_extra_args=None,
+                      scp_extra_args=None,
+                      become=None,
+                      become_method='sudo',
+                      become_user='root',
+                      verbosity=None,
+                      check=False)
+
+    loader = DataLoader()
+    variable_manager = VariableManager()
+    variable_manager.extra_vars = {
+        'hosts': 'all',
+        'roles': 'all',
+    }
+    variable_manager.extra_vars.update(args.extra_vars)
+    
+    inventory = build_inventory(loader, variable_manager, args.groups + args.plays)
+
+    variable_manager.set_inventory(inventory)
+    plays = build_plays(loader, variable_manager, args.playbook, args.plays)
+
+    tqm = TaskQueueManager(
+        inventory=inventory,
+        variable_manager=variable_manager,
+        loader=loader,
+        passwords=None,
+        options=options,
+        stdout_callback='default',
+        run_tree=False,
+    )
+
+    for play in plays:
+        tqm.run(play)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/plugin"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+//const AnsibleLocal = "https://github.com/jonmorehouse/terraform-provi
+
+// this implements the tfrpc.ProvisionerFunc type and returns an instance of a
+// resourceProvisioner when called
+func ResourceProvisionerBuilder() terraform.ResourceProvisioner {
+
+	return &ResourceProvisioner{}
+}
+
+func main() {
+	serveOpts := &plugin.ServeOpts{
+		ProvisionerFunc: ResourceProvisionerBuilder,
+	}
+
+	plugin.Serve(serveOpts)
+}

--- a/provisioner.go
+++ b/provisioner.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-linereader"
+	"io"
+	"os"
+)
+
+type Provisioner struct {
+	useSudo            bool
+	ansibleLocalScript string
+	Playbook           string            `mapstructure:"playbook"`
+	Plays              []string          `mapstructure:"plays"`
+	ModulePath         string            `mapstructure:"module_path"`
+	Groups             []string          `mapstructure:"groups"` // group_vars are expected to be under <ModulePath>/group_var/name
+	ExtraVars          map[string]string `mapstructure:"extra_vars"`
+}
+
+func (p *Provisioner) Run(o terraform.UIOutput, comm communicator.Communicator) error {
+	// commands that are needed to setup a basic environment to run the `ansible-local.py` script
+	// TODO pivot based upon different platforms and allow optional python provision steps
+	provisionAnsibleCommands := []string{
+		"apt-get update",
+		"apt-get install -y build-essential python-dev",
+		"curl https://bootstrap.pypa.io/get-pip.py | sudo python",
+		"pip install ansible",
+	}
+
+	for _, command := range provisionAnsibleCommands {
+		o.Output(fmt.Sprintf("running command: %s", command))
+		err := p.runCommand(o, comm, command)
+		if err != nil {
+			return err
+		}
+	}
+
+	// upload ansible source and playbook to the host
+	if err := comm.UploadDir("/tmp/ansible-module-path", p.ModulePath); err != nil {
+		return err
+	}
+
+	playbook, err := os.Open(p.Playbook)
+	if err != nil {
+		return err
+	}
+	defer playbook.Close()
+	if err := comm.Upload("/tmp/ansible-playbook", playbook); err != nil {
+		return err
+	}
+
+	extraVars, err := json.Marshal(p.ExtraVars)
+	if err != nil {
+		return err
+	}
+
+	// build run command!
+	command := fmt.Sprintf("curl %s | python --module-path=%s --playbook=%s --plays=%s --groups=%s --extra-vars=%s",
+		p.ansibleLocalScript,
+		p.ModulePath,
+		p.Playbook,
+		strings.Join(",", p.Plays),
+		strings.Join(",", p.Groups),
+		string(extraVars))
+
+	if err := p.runCommand(o, comm, command); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provisioner) Validate() error {
+	return nil
+
+	modulePath, err := homedir.Expand(p.ModulePath)
+	if err != nil {
+		return fmt.Errorf("ModulePath is not a valid filepath: %s", p.ModulePath)
+	}
+
+	stat, err := os.Stat(modulePath)
+	if err != nil && os.IsNotExist(err) || stat.IsDir() {
+		return fmt.Errorf("ModulePath is not a valid directory. path: %s", p.ModulePath)
+	}
+
+	playbookPath, err := homedir.Expand(p.Playbook)
+	if err != nil {
+		return fmt.Errorf("Playbook is not a valid filepath. path: %s", p.Playbook)
+	}
+
+	_, err = os.Stat(playbookPath)
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("Playbook is not a valid filepath. path: %s", p.Playbook)
+	}
+
+	for _, play := range p.Plays {
+		if play == "" {
+			return fmt.Errorf("Invalid plays paramter. plays: %s", p.Plays)
+		}
+	}
+
+	for _, group := range p.Groups {
+		if group == "" {
+			return fmt.Errorf("Invalid group. groups: %s", p.Groups)
+		}
+	}
+
+	return nil
+}
+
+func (p *Provisioner) runCommand(
+	o terraform.UIOutput,
+	comm communicator.Communicator,
+	command string) error {
+
+	var err error
+	if p.useSudo {
+		command = "sudo " + command
+	}
+
+	outR, outW := io.Pipe()
+	errR, errW := io.Pipe()
+	outDoneCh := make(chan struct{})
+	errDoneCh := make(chan struct{})
+
+	go p.copyOutput(o, outR, outDoneCh)
+	go p.copyOutput(o, errR, errDoneCh)
+
+	cmd := &remote.Cmd{
+		Command: command,
+		Stdout:  outW,
+		Stderr:  errW,
+	}
+
+	if err := comm.Start(cmd); err != nil {
+		return fmt.Errorf("Error executing command %q: %v", cmd.Command, err)
+	}
+	cmd.Wait()
+	if cmd.ExitStatus != 0 {
+		err = fmt.Errorf(
+			"Command %q exited with non-zero exit status: %d", cmd.Command, cmd.ExitStatus)
+
+	}
+
+	outW.Close()
+	errW.Close()
+	<-outDoneCh
+	<-errDoneCh
+
+	return err
+}
+
+func (p *Provisioner) copyOutput(o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
+	defer close(doneCh)
+	lr := linereader.New(r)
+	for line := range lr.Ch {
+		o.Output(line)
+	}
+}

--- a/provisioner_test.go
+++ b/provisioner_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func createTmpDir(t *testing.T, directoryPrefix string) string {
+	d, err := ioutil.TempDir("", directoryPrefix)
+	if err != nil {
+		t.Fatalf("Unable to create temporary directory")
+	}
+
+	return d
+}
+
+func createTmpFile(t *testing.T, filenamePrefix string) string {
+	// by default, we want to use the operating system's choice of temporary directory
+	f, err := ioutil.TempFile("", filenamePrefix)
+	if err != nil {
+		t.Fatalf("Unable to create temporary file")
+	}
+
+	return f.Name()
+}
+
+func TestProvisioner_good(t *testing.T) {
+	p := &Provisioner{
+		Playbook:   createTmpFile(t, "playbook"),
+		Plays:      []string{"play1", "play2"},
+		ModulePath: createTmpDir(t, "ansible"),
+		Groups:     []string{"all", "terraform"},
+		ExtraVars: map[string]string{
+			"key": "value",
+		},
+	}
+
+	if err := p.Validate(); err != nil {
+		t.Log(err)
+		t.Fatalf("unable to validate properly configured provisioner")
+	}
+}

--- a/resource_provisioner.go
+++ b/resource_provisioner.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/mapstructure"
+	"log"
+	"time"
+)
+
+type ResourceProvisioner struct {
+	playbook   string // filepath for the
+	inventory  string
+	modulePath string // the module path for all group
+
+	groupVars []string          // list of group-vars to be passed to the provisioner
+	extraVars map[string]string // extra variables that can be passed to the provisioner
+}
+
+func (r *ResourceProvisioner) Apply(
+	o terraform.UIOutput,
+	s *terraform.InstanceState,
+	c *terraform.ResourceConfig) error {
+
+	provisioner, err := r.decodeConfig(c)
+	if err != nil {
+		o.Output("erred out here")
+		return err
+	}
+
+	err = provisioner.Validate()
+	if err != nil {
+		o.Output("erred out here 2")
+		return err
+	}
+	provisioner.useSudo = true
+	// TODO: move this to a distribution time embedded variable
+	gitRef := "first-pass"
+	provisioner.ansibleLocalScript = fmt.Sprintf("https://raw.githubusercontent.com/jonmorehouse/terraform-provisioner-ansible/%s/ansible-local.py", gitRef)
+
+	// ensure that this is a linux machine
+	if s.Ephemeral.ConnInfo["type"] != "ssh" {
+		return fmt.Errorf("Unsupported connection type: %s. This provisioner currently only supports linux", s.Ephemeral.ConnInfo["type"])
+	}
+
+	// build a communicator for the provisioner to use
+	comm, err := communicator.New(s)
+	if err != nil {
+		o.Output("erred out here 3")
+		return err
+	}
+
+	err = retryFunc(comm.Timeout(), func() error {
+		err := comm.Connect(o)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	defer comm.Disconnect()
+
+	err = provisioner.Run(o, comm)
+	if err != nil {
+		o.Output("erred out here 4")
+		return err
+	}
+
+	return nil
+}
+
+func (r *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string, es []error) {
+	provisioner, err := r.decodeConfig(c)
+	if err != nil {
+		es = append(es, err)
+		return ws, es
+	}
+
+	err = provisioner.Validate()
+	if err != nil {
+		es = append(es, err)
+		return ws, es
+	}
+
+	return ws, es
+}
+
+func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provisioner, error) {
+	// decodes configuration from terraform and builds out a provisioner
+	p := new(Provisioner)
+	decoderConfig := &mapstructure.DecoderConfig{
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+		Result:           p,
+	}
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// build a map of all configuration values, by default this is going to
+	// pass in all configuration elements for the base configuration as
+	// well as extra values. Build a single value and then from there, continue forth!
+	m := make(map[string]interface{})
+	for k, v := range c.Raw {
+		m[k] = v
+	}
+	for k, v := range c.Config {
+		m[k] = v
+	}
+
+	err = decoder.Decode(m)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func retryFunc(timeout time.Duration, f func() error) error {
+	finish := time.After(timeout)
+
+	for {
+		err := f()
+		if err == nil {
+			return nil
+		}
+		log.Printf("Retryable error: %v", err)
+
+		select {
+		case <-finish:
+			return err
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/resource_provisioner_test.go
+++ b/resource_provisioner_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestResourceProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
+}
+
+// builds and returns a terraform.ResourceConfig object pointer from a map of generic types
+func testConfig(t *testing.T, c map[string]interface{}) *terraform.ResourceConfig {
+	r, err := config.NewRawConfig(c)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	return terraform.NewResourceConfig(r)
+}
+
+func TestResourceProvider_Validate_good(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"groups":      []interface{}{"all", "terraform"},
+		"module_path": createTmpDir(t, "ansible"),
+		"playbook":    createTmpFile(t, "playbook.yml"),
+		"plays":       []interface{}{"test", "test"},
+		"extra_vars": []interface{}{map[string]string{
+			"test": "key",
+		}},
+	})
+
+	r := new(ResourceProvisioner)
+	warn, errs := r.Validate(c)
+
+	if len(warn) > 0 {
+		t.Fatalf("Warnings were not expected")
+	}
+
+	if len(errs) > 0 {
+		t.Fatalf("Errors were not expected")
+	}
+}


### PR DESCRIPTION
This PR introduces some basic scaffolding and a first pass approach at provisioning terraform resources with `ansible`.

At a high level, this provisioner will accept apply a list of plays to a new
terraform resource. Once `local_ansible.py` has been created, this provisioner
will clone that script, install any dependencies to run it and will then
transfer the ansible module path and playbook to the resource before running
that script.

Ansible will only be run on resources when they are first provisioned and as
such this provisioner doesn't have any considerations for an ansible inventory
file or anything such as that. One of the design goals here is that the local
terraform environment doesn't have to know about ansible and doesn't actually
run ansible. This leverages the built in communication functionality that
terraform exposes via the plugin interface and does everything via remote commands.

Here's what this PR introduces:
- [x] basic pluging scaffolding
- [x] basic communication to the remote resource 
- [x] configuration declaration / validation
- [x] local_ansible.py script
- [x] install python and ansible on the remote host
- [x] clone `local_ansible.py` to the remote host
- [x] transfer specified `playbook.yml` and `ansible` to the remote host
- [x] run `local_ansible.py` and report back how things go
