### PR TITLE
ansible-local: extra-vars

### DIFF
--- a/ansible-local.py
+++ b/ansible-local.py
@@ -88,6 +88,8 @@ if __name__ == '__main__':
         args.plays = []
     if not args.hosts:
         args.hosts = []
+    if not args.extra_vars:
+        args.extra_vars = {}
 
     playbook_basedir = os.path.dirname(os.path.abspath(args.playbook))
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION string = "0.0.1"
+const VERSION string = "0.0.2"


### PR DESCRIPTION
Fixing the `extra-vars` arg and ensuring when it is not passed, it is set as a dictionary.

Bumping version to 0.0.2
