### PR TITLE
Fixing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ tar -xvf 0.0.1-terraform-provisioner-ansible.tar.gz /usr/local/bin
 Once installed, a `~/.terraformrc` file is used to _enable_ the plugin.
 
 ```bash
-providers {
+provisioners {
     ansible = "/usr/local/bin/terraform-provisioner-ansible"
 }
 ```
@@ -52,7 +52,7 @@ Additionally, `groups` and `extra_vars` are accessible to resolve variables and 
       groups = ["all"]
       hosts = ["terraform"]
       extra_vars = {
-        "env": "terraform"  
+        "env": "terraform"
       }
     }
   }


### PR DESCRIPTION
Since this is an terraform provisioner, it should be inside a `provisioner` section rather then a `provider`.
